### PR TITLE
Only use xterm if the gvim gui is actually running

### DIFF
--- a/autoload/dasht.vim
+++ b/autoload/dasht.vim
@@ -34,7 +34,7 @@ function! dasht#execute(command, title) abort
 
     " gvim has no terminal emulation, so
     " launch an actual terminal emulator
-    if has('gui')
+    if has('gui') && has('gui_running')
       let command = 'xterm'
             \ .' -T '. shellescape(a:title)
             \ .' -e '. shellescape(command)


### PR DESCRIPTION
Thanks for making dasht.

I noticed that vim-dasht was set to always launch via xterm if vim was built with gui capability, even if the gui was not running.  So for example I have vim.gtk installed in debian, however the gui is only launched if you invoke it as gvim.  If you invoke it in the terminal as vim, it just runs as a normal terminal app, so invoking xterm is not required and at least in my case is less pleasant to look at.

Vim has a feature 'gui_running' to detect this case.  You won't find it documented with :help but you will find it with ':helpgrep gui_running' or ':help gui-extras'

I think dasht would be better off only using xterm if absolutely needed, hence this pull request to check has('gui_running').