### PR TITLE
fix: Do not include file type in docsets when they are set explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,19 @@ A (Neo)Vim plugin for [dasht]( https://github.com/sunaku/dasht ) integration:
     " For example: {{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{
 
       " When in Elixir, also search Erlang:
-      let g:dasht_filetype_docsets['elixir'] = ['erlang']
+      let g:dasht_filetype_docsets['elixir'] = ['elixir', 'erlang']
 
       " When in C++, also search C, Boost, and OpenGL:
-      let g:dasht_filetype_docsets['cpp'] = ['^c$', 'boost', 'OpenGL']
+      let g:dasht_filetype_docsets['cpp'] = ['cpp', '^c$', 'boost', 'OpenGL']
 
       " When in Python, also search NumPy, SciPy, and Pandas:
-      let g:dasht_filetype_docsets['python'] = ['(num|sci)py', 'pandas']
+      let g:dasht_filetype_docsets['python'] = ['python', '(num|sci)py', 'pandas']
 
       " When in HTML, also search CSS, JavaScript, Bootstrap, and jQuery:
-      let g:dasht_filetype_docsets['html'] = ['css', 'js', 'bootstrap']
+      let g:dasht_filetype_docsets['html'] = ['html', 'css', 'js', 'bootstrap']
+
+      " When in Java, search Java SE11, but not JavaScript:
+      let g:dasht_filetype_docsets['java'] = ['java_se11']
 
     " and so on... }}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}
     ```

--- a/autoload/dasht.vim
+++ b/autoload/dasht.vim
@@ -117,7 +117,7 @@ function! dasht#resolve_docsets(docsets) abort
 endfunction
 
 function! s:resolve_single_docset(key) abort
-  return [a:key] + get(get(g:, 'dasht_filetype_docsets', {}), a:key, [])
+  return [] + get(get(g:, 'dasht_filetype_docsets', {}), a:key, [a:key])
 endfunction
 
 let s:function_call_delimiters = '[()[:space:]]\+'

--- a/t/dasht_test.vim
+++ b/t/dasht_test.vim
@@ -109,15 +109,15 @@ describe 'dasht#resolve_docsets'
     Expect dasht#resolve_docsets('foo') == ['foo']
   end
 
-  it 'resolves filetype to itself and definition in dictionary'
+  it 'resolves filetype to definition in dictionary'
     let g:dasht_filetype_docsets = {'foo': []}
-    Expect dasht#resolve_docsets('foo') == ['foo']
+    Expect dasht#resolve_docsets('foo') == []
 
     let g:dasht_filetype_docsets = {'foo': ['bar']}
-    Expect dasht#resolve_docsets('foo') == ['foo', 'bar']
+    Expect dasht#resolve_docsets('foo') == ['bar']
 
     let g:dasht_filetype_docsets = {'foo': ['bar', 'qux']}
-    Expect dasht#resolve_docsets('foo') == ['foo', 'bar', 'qux']
+    Expect dasht#resolve_docsets('foo') == ['bar', 'qux']
   end
 
   it 'resolves filetype for multiple docsets if list is given'
@@ -128,7 +128,7 @@ describe 'dasht#resolve_docsets'
     Expect dasht#resolve_docsets(['foo', 'bar']) == ['foo', 'bar']
 
     let g:dasht_filetype_docsets = {'foo': ['hoge'], 'bar': ['piyo']}
-    Expect dasht#resolve_docsets(['foo', 'bar']) == ['foo', 'hoge', 'bar', 'piyo']
+    Expect dasht#resolve_docsets(['foo', 'bar']) == ['hoge', 'piyo']
   end
 end
 


### PR DESCRIPTION
This change will stop vim-dasht from including the name of the file type in the docsets, because this leads to matches in irrelevant docsets being included in the output.

For example, if the file type is `c`, *all* docsets that have a `c` in its name will be searched.

The user cannot change this behavior from the config, even when setting `g:dasht_filetype_docsets`:

    let g:dasht_filetype_docsets = {}
    let g:dasht_filetype_docsets['java'] = ['Java_SE11', 'JUnit5']

If the user has a `javascript` docset installed, it will still be used for `java` files despite the configuration.

This changes this behavior to always use *only* those docsets that have been specified explicitly by the user. If there is no configuration for the current file type, it falls back to the old behavior and searches in all docsets that have the file type name in their name.